### PR TITLE
Further tweaks

### DIFF
--- a/00_index.ipynb
+++ b/00_index.ipynb
@@ -131,7 +131,7 @@
     "    * Exercise 4: Inversion with devito + dask + scipy **[5min]**\n",
     " \n",
     "\n",
-    "* Session 3: [Performance Optimization and Analysis](performance.ipynb)\n",
+    "* Session 3: [Performance Optimization and Analysis](03_performance.ipynb)\n",
     "    * Introduction to performance optimization in Devito **[2min]**\n",
     "    * Setup for shared-memory parallelism **[5min]**\n",
     "    * Devito Symbolic Engine (DSE) **[5min]**\n",

--- a/00_index.ipynb
+++ b/00_index.ipynb
@@ -24,7 +24,13 @@
    "source": [
     "## Installation and setup\n",
     "\n",
-    "Before we run anything we first need to install the appropriate environement, as well as Devito itself. The following cell will do just that, although it might take a few minutes. This should only be necessary once per session though, so let's get this out of the way now..."
+    "We will run this tutorial interactively in the Azure cloud. To get started, please follow this link and clone the library. **You can use your regular Imperial credentials to log into Azure Notebooks**.\n",
+    "\n",
+    "https://notebooks.azure.com/michael-lange/libraries/devito-tutorial\n",
+    "\n",
+    "Once you have cloned the library, you should open the `00_index.ipynb` notebook to get exactly **here**.\n",
+    "\n",
+    "Now, before we run anything we first need to install the appropriate environement, as well as Devito itself. The following cell will do just that, although it might take a few minutes. This should only be necessary once per session though, so let's get this out of the way now..."
    ]
   },
   {
@@ -40,7 +46,7 @@
     "!pip install -q -r requirements.txt\n",
     "\n",
     "# Install YASK in editable mode; it does runtime SWIG compiles\n",
-    "!pip install -vv -e git+https://github.com/opesci/yask@fix-azure-install#egg=yask\n",
+    "!pip install -e git+https://github.com/opesci/yask@fix-azure-install#egg=yask\n",
     "    \n",
     "# Force YASK oton the path to work around cloud limitations\n",
     "import sys; sys.path += ['/home/nbuser/library/src/yask']"

--- a/00_index.ipynb
+++ b/00_index.ipynb
@@ -31,13 +31,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "!conda config --add channels conda-forge\n",
     "!conda install -y -q --file environment.txt\n",
-    "!pip install -q -r requirements.txt"
+    "!pip install -q -r requirements.txt\n",
+    "\n",
+    "# Install YASK in editable mode; it does runtime SWIG compiles\n",
+    "!pip install -vv -e git+https://github.com/opesci/yask@fix-azure-install#egg=yask\n",
+    "    \n",
+    "# Force YASK oton the path to work around cloud limitations\n",
+    "import sys; sys.path += ['/home/nbuser/library/src/yask']"
    ]
   },
   {
@@ -56,7 +62,8 @@
    "outputs": [],
    "source": [
     "from devito import *\n",
-    "from examples.seismic import model, source"
+    "from examples.seismic import model, source\n",
+    "import yask"
    ]
   },
   {
@@ -173,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.2"
   },
   "widgets": {
    "state": {},

--- a/01_introduction.ipynb
+++ b/01_introduction.ipynb
@@ -657,26 +657,17 @@
    "outputs": [],
    "source": [
     "# Please have a go and try to implement the operator below.\n",
+    "# You will need to follow the same strategy to discretize\n",
+    "# the equation and create a symbolic `update` expression\n",
+    "\n",
     "\n",
     "\n",
     "# Here is a line of boiler plate code that inserts the source term\n",
     "# by interpolating the source signature at each timestep onto the grid.\n",
-    "#source = src.inject(field=u.forward, expr=src * dt**2 / m)\n",
-    "#op = Operator([update] + source)\n",
-    "\n",
-    "# Now we need to run the operator for `nt` timesteps\n",
-    "\n",
-    "u = TimeFunction(name='u', grid=grid, space_order=2, time_order=2)\n",
-    "m = Function(name='m', grid=grid)\n",
-    "m.data[:] = 1. / 1.5**2\n",
-    "\n",
-    "eqn = Eq(m * u.dt2 - u.laplace)\n",
-    "stencil = solve(eqn, u.forward)[0]\n",
-    "update = Eq(u.forward, stencil)\n",
-    "\n",
     "source = src.inject(field=u.forward, expr=src * dt**2 / m)\n",
     "op = Operator([update] + source)\n",
-    "op(t=nt, dt=dt)"
+    "\n",
+    "# Now we need to run the operator for `nt` timesteps"
    ]
   },
   {

--- a/02_seismic_imaging.ipynb
+++ b/02_seismic_imaging.ipynb
@@ -52,7 +52,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -92,7 +94,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -146,13 +150,13 @@
     "    # Set up source data and geometry.\n",
     "    nt = int(1 + (param['tn']-param['t0']) / dt)  # Discrete time axis length\n",
     "\n",
-    "    src = RickerSource(name='src', ndim=2, f0=param['f0'],\n",
+    "    src = RickerSource(name='src', grid=true_model.grid, f0=param['f0'],\n",
     "                       time=np.linspace(param['t0'], param['tn'], nt))\n",
     "    src.coordinates.data[0, :] = [30, param['shot_id']*1000./(param['nshots']-1)]\n",
     "\n",
     "    # Set up receiver data and geometry.\n",
     "    nreceivers = 101  # Number of receiver locations per shot\n",
-    "    rec = Receiver(name='rec', npoint=nreceivers, ntime=nt, ndim=2)\n",
+    "    rec = Receiver(name='rec', grid=true_model.grid, npoint=nreceivers, ntime=nt)\n",
     "    rec.coordinates.data[:, 1] = np.linspace(0, true_model.domain_size[0], num=nreceivers)\n",
     "    rec.coordinates.data[:, 0] = 980. # 20m from the right end\n",
     "\n",
@@ -232,7 +236,8 @@
     "    \n",
     "    # Create symbols to hold the gradient and residual\n",
     "    grad = Function(name=\"grad\", grid=model0.grid)\n",
-    "    residual = Receiver(name='rec', ntime=nt, coordinates=rec.coordinates.data)\n",
+    "    residual = Receiver(name='rec', grid=model0.grid, ntime=nt,\n",
+    "                        coordinates=rec.coordinates.data)\n",
     "    \n",
     "    # Compute simulated data and full forward wavefield u0\n",
     "    d, u0, _ = solver.forward(src=src, m=model0.m, save=True)\n",
@@ -306,7 +311,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -358,7 +365,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "model0.m.data[:] = result.x.reshape(181, 181)\n",
@@ -388,7 +397,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.2"
+  },
+  "widgets": {
+   "state": {},
+   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/03_performance.ipynb
+++ b/03_performance.ipynb
@@ -293,7 +293,7 @@
    },
    "outputs": [],
    "source": [
-    "configuration.core['autotuning'] = 'aggressive'\n",
+    "configuration['autotuning'] = 'aggressive'\n",
     "\n",
     "%run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced -dle advanced -a"
    ]
@@ -347,7 +347,25 @@
     "\n",
     "The fundamental point is that YASK operates at a level of abstraction lower than that of Devito; for example, besides being a static system written in C++, no symbolic language is offered. We've been working on integrating YASK, meaning that, under the hood, Devito may \"offload\" (some of) the `Operator` stencil updates onto YASK. **This is totally transparent to users**; no changes to existing user code are required to exploit YASK! The goal is to create a synergy between the simplicity of use of Devito (i.e., the high-level abstractions) and a powerful optimization system such as YASK, specifically conceived to optimize stencil codes.\n",
     "\n",
-    "So, how do we try out YASK? Again, it's as difficult as setting one more environment variable. Watch out, however, as this is work in progress: the performance may still be quite far from the attainable peaks (e.g., Devito cannot still leverage YASK's auto-tuning system) and some `Operator`s are still unsupported, although our running example should just work out-of-the-box."
+    "So, how do we try out YASK? Again, it's as difficult as setting one more environment variable `DEVITO_BACKEND=yask`. In a notebook, we simply run the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "configuration['backend'] = 'yask'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can experiment a little with YASK. Watch out, however, as this is work in progress: the performance may still be quite far from the attainable peaks (e.g., Devito cannot still leverage YASK's auto-tuning system) and some `Operator`s are still unsupported, although our running example should just work out-of-the-box."
    ]
   },
   {
@@ -358,8 +376,6 @@
    },
    "outputs": [],
    "source": [
-    "configuration.core['backend'] = 'yask'\n",
-    "\n",
     "%run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced"
    ]
   },

--- a/03_performance.ipynb
+++ b/03_performance.ipynb
@@ -36,7 +36,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
     "\n",
     "## Shared-memory parallelism\n",
     "\n",
-    "We start with the most obvious -- parallelism. Devito implements shared-memory parallelism via OpenMP. To enable it, the following environment variable needs to be set:"
+    "We start with the most obvious -- parallelism. Devito implements shared-memory parallelism via OpenMP. To enable it, we would usually simply set following the environment variable `export DEVITO_OPENMP=1`. However, since we are running in Jupyter notebook, we can change the relevant configuration option directly:"
    ]
   },
   {
@@ -88,7 +88,8 @@
    },
    "outputs": [],
    "source": [
-    "%env DEVITO_OPENMP=1"
+    "from devito import configuration\n",
+    "configuration['openmp'] = True"
    ]
   },
   {
@@ -106,7 +107,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -158,26 +159,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We run the isotropic acoustic forward operator again, but this time with a much larger grid, a 512x512x512 cube, and a more realistic space order, 8. We also shorten the duration by deliberately choosing a very small simulation end time (50 ms)."
+    "We run the isotropic acoustic forward operator again, but this time with a much larger grid, a 256x256x256 cube, and a more realistic space order, 8. We also shorten the duration by deliberately choosing a very small simulation end time (50 ms)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "# Thread pinning\n",
-    "%env KMP_HW_SUBSET=8c,1t\n",
-    "%env KMP_AFFINITY=compact\n",
-    "# Tell Devito to use the Intel compiler\n",
-    "%env DEVITO_ARCH=intel\n",
-    "# or, equivalently, programmatically\n",
-    "from devito import configuration\n",
-    "configuration['compiler'] = 'intel'\n",
-    "\n",
     "for i in range(3):\n",
     "    print (\"Run %d\" % i)\n",
     "    %run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50"
@@ -216,9 +208,9 @@
    "outputs": [],
    "source": [
     "# Increase Devito logger verbosity to display useful information about the DSE\n",
-    "%env DEVITO_LOGGING=DEBUG\n",
+    "configuration['log_level'] = 'DEBUG'\n",
     "\n",
-    "run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced"
+    "%run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced"
    ]
   },
   {
@@ -250,9 +242,7 @@
     "* SIMD Vectorization\n",
     "* Loop blocking\n",
     "* Optimization of so called \"remainder\" loops\n",
-    "* Creation of elemental functions\n",
-    "\n",
-    "Before enabling the DLE, let's first run a problem bigger than those tried in the previous sections. We pick a 512\\*\\*3 grid to be 100% sure that the working set of our simulation won't fit in some level of cache."
+    "* Creation of elemental functions"
    ]
   },
   {
@@ -263,7 +253,7 @@
    },
    "outputs": [],
    "source": [
-    "run $benchmark run -P acoustic -so 8 -d 512 512 512 --tn 50 -dse advanced"
+    "%run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced"
    ]
   },
   {
@@ -281,7 +271,7 @@
    },
    "outputs": [],
    "source": [
-    "run $benchmark run -P acoustic -so 8 -d 512 512 512 --tn 50 -dse advanced -dle advanced"
+    "%run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced -dle advanced"
    ]
   },
   {
@@ -292,7 +282,7 @@
     "\n",
     "What we are missing so far is performance tuning. Take loop blocking, for example. This is a *parametric loop transformation*: its impact will vary depending on block shape, size and scheduling. In the literature, over the years, dozens of different loop blocking strategies have been studied! Even though we used the simplest loop blocking scheme on Earth, we would need **at least** to come up with a block size fitting in some level of cache. Obviously, this is such a low level detail... and we don't want users to waste any time on thinking about these matters!\n",
     "\n",
-    "Like other frameworks, Devito can automatically detect a \"sufficiently good\" block size through an *auto-tuning engine*. Let's try it out; in particular, we tell Devito to be \"aggressive\" in the search for block sizes. Being \"aggressive\" means that more time will be spent on auto-tuning, but there's a greater chance of retrieving a better candidate. We do this through the `DEVITO_AUTOTUNING` environment variable."
+    "Like other frameworks, Devito can automatically detect a \"sufficiently good\" block size through an *auto-tuning engine*. Let's try it out; in particular, we tell Devito to be \"aggressive\" in the search for block sizes. Being \"aggressive\" means that more time will be spent on auto-tuning, but there's a greater chance of retrieving a better candidate. We can either do this by setting an environment variable (`export DEVITO_AUTOTUNING=aggressive`) or directly through the configuratio dictionary."
    ]
   },
   {
@@ -303,15 +293,16 @@
    },
    "outputs": [],
    "source": [
-    "%env DEVITO_AUTOTUNING=aggressive\n",
-    "run $benchmark run -P acoustic -so 8 -d 512 512 512 --tn 50 -dse advanced -dle advanced -a"
+    "configuration.core['autotuning'] = 'aggressive'\n",
+    "\n",
+    "%run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced -dle advanced -a"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note the addition of `-a` to the arguments list of our benchmarking script. This enables auto-tuning; the `DEVITO_AUTOTUNING=aggressive` environment variable drives the auto-tuner search.\n",
+    "Note the addition of `-a` to the arguments list of our benchmarking script. This enables auto-tuning; the `aggressive` setting drives the auto-tuner search.\n",
     "\n",
     "Do you note any difference in performance? Why?"
    ]
@@ -367,8 +358,9 @@
    },
    "outputs": [],
    "source": [
-    "%env DEVITO_BACKEND=yask\n",
-    "run $benchmark run -P acoustic -so 8 -d 512 512 512 --tn 50 -dse advanced"
+    "configuration.core['backend'] = 'yask'\n",
+    "\n",
+    "%run $benchmark run -P acoustic -so 8 -d 256 256 256 --tn 50 -dse advanced"
    ]
   },
   {
@@ -402,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.2"
   },
   "widgets": {
    "state": {},

--- a/environment.txt
+++ b/environment.txt
@@ -10,3 +10,4 @@ psutil>=5.1.0
 py-cpuinfo
 dask
 distributed
+swig


### PR DESCRIPTION
This is a bit of a WIP, but brings many small good things:
* Link to root library in `index.ipynb`
* Install procedure for YASK (not complete yet, see below)
* Tweaks to the performance section to switch options via configurations and reduce grid sizes
* Fix to the "Making a Wave" exercise

Note, the YASK install procedure is slightly hacky and only works partially. It installs a local clone and sets the PYTHONPATH manually, but for some reason the import following runtime SWIG compiles still fails. This is WIP, but I'd like it merged today before the tutorial dry-run.